### PR TITLE
Fixed responsiveness and updated Tech Secy info

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -151,6 +151,7 @@
 .speaker-text {
     font-size: 1.3vw;
     font-family: "AvenirLTStd-Medium";
+    overflow-wrap: break-word;
 }
 
 .speaker-company {
@@ -163,6 +164,7 @@
 
 .speaker-name {
     padding-top:5%;
+    font-size: 3vw;
 }
 
 .circle{
@@ -258,6 +260,9 @@
     .speaker-text {
         font-size: 2vw;
     }
+    .speaker-name {
+        font-size: 3vw;
+    }
     
 }
 
@@ -329,7 +334,9 @@
         font-size: 3vw;
         text-align: center;
     }
-
+    .speaker-name {
+        font-size: 4vw;
+    }
     .featurette-heading {
         margin-top: -8%;
         font-size: 6.2vw;
@@ -347,8 +354,8 @@
     .circle{
         border-radius:50%;
         border:4px solid #FFFFFF;
-        width:130px;
-        height:130px;
+        width:100%;
+        height: auto;
     }
 
     /* For navwheel to become according to window size for small devices */

--- a/css/main.css
+++ b/css/main.css
@@ -164,7 +164,7 @@
 
 .speaker-name {
     padding-top:5%;
-    font-size: 3vw;
+    font-size: 2vw;
 }
 
 .circle{

--- a/css/main.css
+++ b/css/main.css
@@ -174,22 +174,26 @@
 
 #services {
     text-align: center;
-    padding-left: 1.8vw
 }
 
 .service-list {
+    width: 100%;
     display: flex;
-    justify-content: center;
+    align-content: center;
+    flex-direction: row;
+    justify-content: space-around;
+    flex-wrap: wrap;
 }
 
 .service-card {
     height: 300px;
     width: 200px;
     border: 2px solid #FFFFFF;
-    border-radius: 3px;
+    border-radius: 10px;
     margin: 2rem;
     color: #FFFFFF;
     font-size: 2rem;
+    padding:10px;
 }
 
 @media only screen and (max-width: 990px) {
@@ -254,9 +258,7 @@
     .speaker-text {
         font-size: 2vw;
     }
-    .service-list {
-        display: inline-block;
-    }
+    
 }
 
 @media only screen and (max-width: 600px) {
@@ -357,7 +359,4 @@
         margin-bottom: 40px !important;
     }
 
-    .service-list {
-        display: inline-block;
-    }
 } 

--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@
         <div class="list-head col-xs-5 col-sm-5 col-md-5 contact-right circle-holder">
                 <img src="images/abhigyank.jpg" class="circle">
                 <br>
-                <p class="speaker-text speaker-name">Abhigyan Khaund</p>
+                <p class="speaker-text speaker-name">Vipul Sharma</p>
                 <p class="speaker-text speaker-about">Technical Secretary</p>
                 <p class="speaker-text speaker-about">technical_secretary[at]students.iitmandi.ac.in <i class="fas fa-envelope"></i></p>
         </div>

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
     </div>
     <div class="container marketing">
         <div id="services">
-            <h3>Services currently hosted on the SNTC Server are-</h3>
+            <h3>Services currently hosted on the SNTC Server</h3>
             <ul class="service-list">
                 <li>
                     <div class="service-card">
@@ -194,7 +194,7 @@
             For any queries related to Science and Technology Council (SNTC) or any of its clubs, please contact the Technical Secretary at the given details.
         </div>
         <div class="list-head col-xs-5 col-sm-5 col-md-5 contact-right circle-holder">
-                <img src="images/abhigyank.jpg" class="circle">
+                <img src="images/vipul.jpeg" class="circle">
                 <br>
                 <p class="speaker-text speaker-name">Vipul Sharma</p>
                 <p class="speaker-text speaker-about">Technical Secretary</p>


### PR DESCRIPTION
### 1.Updated Tech Secy info
### 2.The "flex-wrap" for "services available" on the services page was not set to "wrap". The css was using media query to convert it into a single column which wasted a lot of space on the page.
### 3.The tech secy photo was of a constant width which broke the layout below 600 px. Also the email was too long, so it broke out of the div on smaller screens. 

## Before
![Screenshot from 2020-10-03 07-08-39](https://user-images.githubusercontent.com/53950730/94980565-83166800-0548-11eb-87a2-e7f2827116d4.png)
## After
![Screenshot from 2020-10-03 07-08-57](https://user-images.githubusercontent.com/53950730/94980566-84e02b80-0548-11eb-948f-15b5dbf6c3e3.png)

## Before
![Screenshot from 2020-10-03 07-09-32](https://user-images.githubusercontent.com/53950730/94980567-86115880-0548-11eb-864f-7ac0947be110.png)
#After
![Screenshot from 2020-10-03 07-09-56](https://user-images.githubusercontent.com/53950730/94980569-86a9ef00-0548-11eb-97b5-337afd53bf30.png)





 